### PR TITLE
[SP-5370] Backport of PDI-17775 - Process Files step no longer suppor…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
     <!-- License Configuration -->
     <license.licenseName>apache_v2</license.licenseName>
 
-    <commons-vfs2.version>2.2</commons-vfs2.version>
     <hadoop-core.version>0.20.2</hadoop-core.version>
 
     <!-- Test dependencies -->
     <hadoop-test.version>0.20.2</hadoop-test.version>
     <commons-io.version>1.4</commons-io.version>
+    <powermock.version>1.7.3</powermock.version>
   </properties>
 
   <scm>
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>${commons-vfs2.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -62,6 +61,18 @@
           <artifactId>hsqldb</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- 'TEST' SCOPED DEPS -->

--- a/src/test/java/org/pentaho/hdfs/vfs/test/MapRFileNameParserTest.java
+++ b/src/test/java/org/pentaho/hdfs/vfs/test/MapRFileNameParserTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2020 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,55 +18,112 @@
 package org.pentaho.hdfs.vfs.test;
 
 import org.apache.commons.vfs2.FileName;
-import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.commons.vfs2.provider.FileNameParser;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
 import org.pentaho.hdfs.vfs.MapRFileNameParser;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for parsing MapR FileSystem URIs.
  *
  * @author Jordan Ganoff (jganoff@pentaho.com)
  */
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( { UriParser.class, VFS.class } )
 public class MapRFileNameParserTest {
 
-  @Test
-  public void rootPathNoClusterName() throws FileSystemException {
-    final String URI = "maprfs:///";
+  private static final String PREFIX = "maprfs";
+  private static final String BASE_PATH = "//";
+  private static final String BASE_URI = PREFIX + ":" + BASE_PATH;
 
-    FileNameParser parser = new MapRFileNameParser();
-    FileName name = parser.parseUri(null, null, URI);
+  private StandardFileSystemManager fsm;
 
-    assertEquals(URI, name.getURI());
-    assertEquals("maprfs", name.getScheme());
+  @Before
+  public void setUp() throws Exception {
+    mockStatic( VFS.class );
+    mockStatic( UriParser.class );
+    spy( UriParser.class );
+
+    fsm = mock( StandardFileSystemManager.class );
+    when( VFS.getManager() ).thenReturn( fsm );
   }
 
   @Test
-  public void withPath() throws FileSystemException
-  {
-    final String URI = "maprfs:///my/file/path";
+  public void rootPathNoClusterName() throws Exception {
+    final String FILEPATH = "/";
+    final String URI = BASE_URI + FILEPATH;
+
+    buildExtractSchemeMocks( PREFIX, URI, BASE_PATH + FILEPATH );
 
     FileNameParser parser = new MapRFileNameParser();
-    FileName name = parser.parseUri(null, null, URI);
+    FileName name = parser.parseUri( null, null, URI );
 
-    assertEquals(URI, name.getURI());
-    assertEquals("maprfs", name.getScheme());
-    assertEquals("/my/file/path", name.getPath());
+    assertEquals( URI, name.getURI() );
+    assertEquals( PREFIX, name.getScheme() );
   }
 
   @Test
-  public void withPathAndClusterName() throws FileSystemException {
-    final String URI = "maprfs://cluster2/my/file/path";
+  public void withPath() throws Exception  {
+    final String FILEPATH = "/my/file/path";
+    final String URI = BASE_URI + FILEPATH;
+
+    buildExtractSchemeMocks( PREFIX, URI, BASE_PATH + FILEPATH );
 
     FileNameParser parser = new MapRFileNameParser();
-    FileName name = parser.parseUri(null, null, URI);
+    FileName name = parser.parseUri( null, null, URI );
 
-    assertEquals(URI, name.getURI());
-    assertEquals("maprfs", name.getScheme());
-    assertTrue(name.getURI().startsWith("maprfs://cluster2/"));
-    assertEquals("/my/file/path", name.getPath());
+    assertEquals( URI, name.getURI() );
+    assertEquals( PREFIX, name.getScheme() );
+    assertEquals( FILEPATH, name.getPath() );
+  }
+
+  @Test
+  public void withPathAndClusterName() throws Exception {
+    final String HOST = "cluster2";
+    final String FILEPATH = "/my/file/path";
+    final String URI = BASE_URI + HOST + FILEPATH;
+
+    buildExtractSchemeMocks( PREFIX, URI, BASE_PATH + HOST + FILEPATH );
+
+    FileNameParser parser = new MapRFileNameParser();
+    FileName name = parser.parseUri( null, null, URI );
+
+    assertEquals( URI, name.getURI() );
+    assertEquals( PREFIX, name.getScheme() );
+    assertTrue( name.getURI().startsWith( PREFIX + ":" + BASE_PATH + HOST ) );
+    assertEquals( FILEPATH, name.getPath() );
+  }
+
+  private Answer buildSchemeAnswer( String prefix, String buildPath ) {
+    Answer extractSchemeAnswer = invocation -> {
+      Object[] args = invocation.getArguments();
+      ( (StringBuilder) args[2] ).append( buildPath );
+      return prefix;
+    };
+    return extractSchemeAnswer;
+  }
+
+  private void buildExtractSchemeMocks( String prefix, String fullPath, String pathWithoutPrefix ) throws Exception {
+    String[] schemes = { "maprfs" };
+    when( fsm.getSchemes() ).thenReturn( schemes );
+    doAnswer( buildSchemeAnswer( prefix, pathWithoutPrefix ) ).when( UriParser.class, "extractScheme",
+      eq( schemes ), eq( fullPath ), any( StringBuilder.class ) );
   }
 }


### PR DESCRIPTION
…ts HTTP scheme (9.0 Suite)

Cherry pick from: https://github.com/pentaho/pentaho-hdfs-vfs/pull/21

This PR is part of a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/220
- https://github.com/pentaho/apache-vfs-browser/pull/61
- https://github.com/pentaho/big-data-plugin/pull/2035
- https://github.com/webdetails/cpk/pull/86
- https://github.com/pentaho/data-access/pull/1090
- https://github.com/pentaho/mondrian/pull/1197
- https://github.com/pentaho/pdi-jms-plugin/pull/75
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/103
- https://github.com/pentaho/pdi-plugins-ee/pull/170
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/83
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/52
- https://github.com/pentaho/pentaho-big-data-ee/pull/442
- https://github.com/pentaho/pentaho-commons-database/pull/178
- https://github.com/pentaho/pentaho-data-mining/pull/25
- https://github.com/pentaho/pentaho-det-ee/pull/615
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/22
- https://github.com/pentaho/pentaho-karaf-assembly/pull/634
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/286
- https://github.com/pentaho/pentaho-kettle/pull/7313
- https://github.com/pentaho/pentaho-metaverse/pull/620
- https://github.com/pentaho/pentaho-osgi-bundles/pull/362
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1503
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/340
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/789
- https://github.com/pentaho/pentaho-platform/pull/4651
- https://github.com/pentaho/pentaho-reporting/pull/1328
- https://github.com/pentaho/pentaho-s3-vfs/pull/93
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/16