### PR TITLE
Revert "Merge pull request #22 from gryphendowre/SP-5370"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
     <!-- License Configuration -->
     <license.licenseName>apache_v2</license.licenseName>
 
+    <commons-vfs2.version>2.2</commons-vfs2.version>
     <hadoop-core.version>0.20.2</hadoop-core.version>
 
     <!-- Test dependencies -->
     <hadoop-test.version>0.20.2</hadoop-test.version>
     <commons-io.version>1.4</commons-io.version>
-    <powermock.version>1.7.3</powermock.version>
   </properties>
 
   <scm>
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
+      <version>${commons-vfs2.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -61,18 +62,6 @@
           <artifactId>hsqldb</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- 'TEST' SCOPED DEPS -->

--- a/src/test/java/org/pentaho/hdfs/vfs/test/MapRFileNameParserTest.java
+++ b/src/test/java/org/pentaho/hdfs/vfs/test/MapRFileNameParserTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2020 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,112 +18,55 @@
 package org.pentaho.hdfs.vfs.test;
 
 import org.apache.commons.vfs2.FileName;
-import org.apache.commons.vfs2.VFS;
-import org.apache.commons.vfs2.impl.StandardFileSystemManager;
+import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.provider.FileNameParser;
-import org.apache.commons.vfs2.provider.UriParser;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.stubbing.Answer;
 import org.pentaho.hdfs.vfs.MapRFileNameParser;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.powermock.api.mockito.PowerMockito.doAnswer;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for parsing MapR FileSystem URIs.
  *
  * @author Jordan Ganoff (jganoff@pentaho.com)
  */
-@RunWith( PowerMockRunner.class )
-@PrepareForTest( { UriParser.class, VFS.class } )
 public class MapRFileNameParserTest {
 
-  private static final String PREFIX = "maprfs";
-  private static final String BASE_PATH = "//";
-  private static final String BASE_URI = PREFIX + ":" + BASE_PATH;
+  @Test
+  public void rootPathNoClusterName() throws FileSystemException {
+    final String URI = "maprfs:///";
 
-  private StandardFileSystemManager fsm;
+    FileNameParser parser = new MapRFileNameParser();
+    FileName name = parser.parseUri(null, null, URI);
 
-  @Before
-  public void setUp() throws Exception {
-    mockStatic( VFS.class );
-    mockStatic( UriParser.class );
-    spy( UriParser.class );
-
-    fsm = mock( StandardFileSystemManager.class );
-    when( VFS.getManager() ).thenReturn( fsm );
+    assertEquals(URI, name.getURI());
+    assertEquals("maprfs", name.getScheme());
   }
 
   @Test
-  public void rootPathNoClusterName() throws Exception {
-    final String FILEPATH = "/";
-    final String URI = BASE_URI + FILEPATH;
-
-    buildExtractSchemeMocks( PREFIX, URI, BASE_PATH + FILEPATH );
+  public void withPath() throws FileSystemException
+  {
+    final String URI = "maprfs:///my/file/path";
 
     FileNameParser parser = new MapRFileNameParser();
-    FileName name = parser.parseUri( null, null, URI );
+    FileName name = parser.parseUri(null, null, URI);
 
-    assertEquals( URI, name.getURI() );
-    assertEquals( PREFIX, name.getScheme() );
+    assertEquals(URI, name.getURI());
+    assertEquals("maprfs", name.getScheme());
+    assertEquals("/my/file/path", name.getPath());
   }
 
   @Test
-  public void withPath() throws Exception  {
-    final String FILEPATH = "/my/file/path";
-    final String URI = BASE_URI + FILEPATH;
-
-    buildExtractSchemeMocks( PREFIX, URI, BASE_PATH + FILEPATH );
+  public void withPathAndClusterName() throws FileSystemException {
+    final String URI = "maprfs://cluster2/my/file/path";
 
     FileNameParser parser = new MapRFileNameParser();
-    FileName name = parser.parseUri( null, null, URI );
+    FileName name = parser.parseUri(null, null, URI);
 
-    assertEquals( URI, name.getURI() );
-    assertEquals( PREFIX, name.getScheme() );
-    assertEquals( FILEPATH, name.getPath() );
-  }
-
-  @Test
-  public void withPathAndClusterName() throws Exception {
-    final String HOST = "cluster2";
-    final String FILEPATH = "/my/file/path";
-    final String URI = BASE_URI + HOST + FILEPATH;
-
-    buildExtractSchemeMocks( PREFIX, URI, BASE_PATH + HOST + FILEPATH );
-
-    FileNameParser parser = new MapRFileNameParser();
-    FileName name = parser.parseUri( null, null, URI );
-
-    assertEquals( URI, name.getURI() );
-    assertEquals( PREFIX, name.getScheme() );
-    assertTrue( name.getURI().startsWith( PREFIX + ":" + BASE_PATH + HOST ) );
-    assertEquals( FILEPATH, name.getPath() );
-  }
-
-  private Answer buildSchemeAnswer( String prefix, String buildPath ) {
-    Answer extractSchemeAnswer = invocation -> {
-      Object[] args = invocation.getArguments();
-      ( (StringBuilder) args[2] ).append( buildPath );
-      return prefix;
-    };
-    return extractSchemeAnswer;
-  }
-
-  private void buildExtractSchemeMocks( String prefix, String fullPath, String pathWithoutPrefix ) throws Exception {
-    String[] schemes = { "maprfs" };
-    when( fsm.getSchemes() ).thenReturn( schemes );
-    doAnswer( buildSchemeAnswer( prefix, pathWithoutPrefix ) ).when( UriParser.class, "extractScheme",
-      eq( schemes ), eq( fullPath ), any( StringBuilder.class ) );
+    assertEquals(URI, name.getURI());
+    assertEquals("maprfs", name.getScheme());
+    assertTrue(name.getURI().startsWith("maprfs://cluster2/"));
+    assertEquals("/my/file/path", name.getPath());
   }
 }


### PR DESCRIPTION
This reverts commit 66a00e17836dad906664ff5cef79463dc54e9c42, reversing
changes made to 2f9d8d6611a48a4fad87bf32f463b4aa4e5cd0d7.

This Revert PR is part of a series:
- https://github.com/pentaho/maven-parent-poms/pull/229
- https://github.com/pentaho/apache-vfs-browser/pull/62
- https://github.com/pentaho/big-data-plugin/pull/2040
- https://github.com/webdetails/cpk/pull/87
- https://github.com/pentaho/data-access/pull/1091
- https://github.com/pentaho/mondrian/pull/1202
- https://github.com/pentaho/pdi-jms-plugin/pull/76
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/104
- https://github.com/pentaho/pdi-plugins-ee/pull/174
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/84
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/53
- https://github.com/pentaho/pentaho-big-data-ee/pull/444
- https://github.com/pentaho/pentaho-commons-database/pull/179
- https://github.com/pentaho/pentaho-data-mining/pull/26
- https://github.com/pentaho/pentaho-det-ee/pull/616
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/23
- https://github.com/pentaho/pentaho-karaf-assembly/pull/635
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/290
- https://github.com/pentaho/pentaho-kettle/pull/7334
- https://github.com/pentaho/pentaho-metaverse/pull/621
- https://github.com/pentaho/pentaho-osgi-bundles/pull/363
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1504
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/341
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/790
- https://github.com/pentaho/pentaho-platform/pull/4658
- https://github.com/pentaho/pentaho-reporting/pull/1342
- https://github.com/pentaho/pentaho-s3-vfs/pull/94
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/17